### PR TITLE
fix: disable TSFE level cache

### DIFF
--- a/Classes/Service/Tsfe.php
+++ b/Classes/Service/Tsfe.php
@@ -151,7 +151,6 @@ class Tsfe implements SingletonInterface
             try {
                 $serverRequest = $serverRequest->withAttribute('frontend.controller', $tsfe);
                 $tsfe->determineId($serverRequest);
-                $tsfe->no_cache = false;
                 /** @var ServerRequest $serverRequest */
                 $serverRequest = $tsfe->getFromCache($serverRequest);
                 // The manual releasing of locks is low level api and should be avoided in EXT:solr.


### PR DESCRIPTION
that can result in reusing cache results that do not consider the matched API route. Cache on app_routes level is sufficient