### PR TITLE
ci: raise PHPStan level to 4

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -3,22 +3,46 @@ name: PHPStan
 on:
   pull_request:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   phpstan:
     runs-on: ubuntu-latest
+
     steps:
-      - name: Checkout repository
+      - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up PHP
+      - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.3'
-          extensions: intl, mbstring
+          coverage: none
           tools: composer:v2
 
       - name: Install dependencies
-        run: composer install --no-interaction --prefer-dist --no-progress --ignore-platform-reqs
+        run: composer update --prefer-dist --no-interaction --no-progress
 
-      - name: Run PHPStan
+      - name: Run PHPStan level 4
+        run: composer phpstan
+
+  phpstan-lowest:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: none
+          tools: composer:v2
+
+      - name: Install lowest dependencies
+        run: composer update --prefer-lowest --prefer-dist --no-interaction --no-progress
+
+      - name: Run PHPStan level 4
         run: composer phpstan

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-  level: 2
+  level: 4
   paths:
     - Classes
     - ext_localconf.php


### PR DESCRIPTION
No errors at level 4 — codebase was already clean.

Updated phpstan.yml CI workflow: add lowest-deps job, FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 env, align step names and structure with project conventions.